### PR TITLE
use arm64 compatible docker image for startup script

### DIFF
--- a/livekit-server/templates/daemonset.yaml
+++ b/livekit-server/templates/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
       - name: daemonset
-        image: gcr.io/google-containers/startup-script:v2
+        image: cilium/startup-script:2de58e53a7060593c91d0655b337a57f06bf5d66-dev        
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
This should fix #21 . I've created a helm package manually from the repository and installed it to an AWS cluster. The pod shows running in kubectl and the logs show the script ran. The tag for the image is the most recent that supports arm64. I have not tested this on a amd64 setup. 