### PR TITLE
Enable autoscaling/v2beta2 for avoid warnings (livekit/livekit-server)

### DIFF
--- a/livekit-server/templates/hpa.yaml
+++ b/livekit-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "livekit-server.fullname" . }}

--- a/livekit-server/templates/hpa.yaml
+++ b/livekit-server/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta1
+{{- end -}}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "livekit-server.fullname" . }}


### PR DESCRIPTION
Get rid warning message "autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler"