### PR TITLE
modify nginx ingress to support kubernetes >= 1.18

### DIFF
--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -22,17 +22,36 @@ metadata:
   {{- end }}
   {{- if eq .Values.loadBalancer.type "do" }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ .Values.loadBalancer.clusterIssuer }}
   {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 spec:
+  {{- if eq .Values.loadBalancer.type "do" }}
+  ingressClassName: nginx
+  rules:
+  {{- range .Values.loadBalancer.tls }}
+  {{- range .hosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $svcPort }}
+  {{- end }}
+  {{- end }}
+  {{- else -}}
   defaultBackend:
     service:
       name:  {{ $fullName }}
       port:
         number: {{ $svcPort }}
+  {{- end }}
+
 {{- else -}}
 apiVersion: extensions/v1beta1
 spec:


### PR DESCRIPTION
I was trying to set up on DigitalOcean but SSL was not working. Later, I found that the syntax was changed in the new Kubernetes API. After making the changes mentioned in this PR, I could get SSL working. 

Reference: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#setting-a-default-ingressclass 