### PR TITLE
feat(turnloadbalancer): add possibility to add annotations

### DIFF
--- a/livekit-server/templates/turnloadbalancer.yaml
+++ b/livekit-server/templates/turnloadbalancer.yaml
@@ -5,6 +5,10 @@ metadata:
   name: '{{ include "livekit-server.fullname" . }}-turn'
   labels:
     {{- include "livekit-server.labels" . | nindent 4 }}
+  {{- with .Values.livekit.turn.loadBalancerAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.livekit.turn.external_tls }}
   type: LoadBalancer

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -31,6 +31,7 @@ livekit:
     # Must match domain of your tls cert
     # domain: turn.myhost.com
     # secretName: <tlssecret>
+    loadBalancerAnnotations: {}
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This PR adds the possibility to add annotations to the turn service.  
One use case for this is e.g. to specify a `external-dns.alpha.kubernetes.io/hostname` annotation for [external-dns](https://github.com/kubernetes-sigs/external-dns).