### PR TITLE
Set configmap checksum on deployments annotations

### DIFF
--- a/egress/templates/deployment.yaml
+++ b/egress/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "egress.selectorLabels" . | nindent 8 }}
     spec:

--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "livekit-server.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
I noticed that the deployments (both egress and livekit-server) were not being restarted automatically after changing some configuration on the configmap. 
This PR fixes that by setting the configmap checksum on the annotations, as recommended on the [official helm documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).