### PR TITLE
Make TURN service type configurable

### DIFF
--- a/livekit-server/templates/turnloadbalancer.yaml
+++ b/livekit-server/templates/turnloadbalancer.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ default "LoadBalancer" .Values.livekit.turn.service_type }} 
+  type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }} 
   ports:
     - port: 443
       targetPort: {{ .Values.livekit.turn.tls_port }}

--- a/livekit-server/templates/turnloadbalancer.yaml
+++ b/livekit-server/templates/turnloadbalancer.yaml
@@ -10,9 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.livekit.turn.external_tls }}
-  type: LoadBalancer
-  {{- end }}
+  type: {{ default "LoadBalancer" .Values.livekit.turn.service_type }} 
   ports:
     - port: 443
       targetPort: {{ .Values.livekit.turn.tls_port }}

--- a/server-sample.yaml
+++ b/server-sample.yaml
@@ -44,6 +44,9 @@ livekit:
     # Kubernetes Secret containing TLS cert for <turn.myhost.com>
     # See https://docs.livekit.io/deploy/kubernetes/#importing-ssl-certificates
     secretName: <tlssecret>
+    # set the Kubernetes serviceType for the TURN service. By default it sets it to "LoadBalancer"
+    # See kubernetes serviceTypes on official documentation: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    service_type: "LoadBalancer"
 
 loadBalancer:
   # valid values: disable, alb, aws, gke, gke-managed-cert, do

--- a/server-sample.yaml
+++ b/server-sample.yaml
@@ -46,7 +46,7 @@ livekit:
     secretName: <tlssecret>
     # set the Kubernetes serviceType for the TURN service. By default it sets it to "LoadBalancer"
     # See kubernetes serviceTypes on official documentation: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-    service_type: "LoadBalancer"
+    serviceType: "LoadBalancer"
 
 loadBalancer:
   # valid values: disable, alb, aws, gke, gke-managed-cert, do


### PR DESCRIPTION
This makes the service type for TURN completely configurable from the client side, making no assumptions about provider, external tls, etc.
Fixes #45.