### PR TITLE
adding gke-vpc-native loadbalancer configuration

### DIFF
--- a/examples/server-gke-vpc-native.yaml
+++ b/examples/server-gke-vpc-native.yaml
@@ -1,0 +1,41 @@
+# Deploy LiveKit into a VPC-native GKE cluster
+# see https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips
+
+replicaCount: 2
+
+# Refer to https://docs.livekit.io/deploy/kubernetes/ for instructions
+
+livekit:
+  rtc:
+    use_external_ip: true
+  redis:
+    address: <redis-address>:6379
+  keys:
+    <key>: <secret>
+  turn:
+    enabled: true
+    domain: <turn-address>
+    tls_port: 3478
+    secretName: <turn-tls-secret>
+
+loadBalancer:
+  type: gke-vpc-native
+  tls:
+    - hosts:
+        - <server-address>
+      secretName: <server-tls-secret>
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 60
+
+# resources are set assuming a 8 core instance
+resources:
+  limits:
+    cpu: 7500m
+    memory: 2048Mi
+  requests:
+    cpu: 7000m
+    memory: 1024Mi

--- a/livekit-server/templates/backendconfig.yaml
+++ b/livekit-server/templates/backendconfig.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") -}}
+{{- if or (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") (eq .Values.loadBalancer.type "gke-vpc-native") -}}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -54,6 +54,7 @@ spec:
               number: {{ $svcPort }}
   {{- end }}
   {{- end }}
+{{- if ne .Values.loadBalancer.type "gke-vpc-native" }}
 {{- with .Values.loadBalancer }}
   {{- if .tls }}
   tls:
@@ -67,7 +68,8 @@ spec:
       secretName: {{ .secretName | quote }}
       {{- end }}
     {{- end }}
-    {{- end }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -55,21 +55,21 @@ spec:
   {{- end }}
   {{- end }}
 {{- if ne .Values.loadBalancer.type "gke-vpc-native" }}
-{{- with .Values.loadBalancer }}
-  {{- if .tls }}
-  tls:
-    {{- range .tls }}
-    {{- if .hosts }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
+  {{- with .Values.loadBalancer }}
+    {{- if .tls }}
+    tls:
+      {{- range .tls }}
+      {{- if .hosts }}
+      - hosts:
+          {{- range .hosts }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- if .secretName }}
+        secretName: {{ .secretName | quote }}
         {{- end }}
-      {{- if .secretName }}
-      secretName: {{ .secretName | quote }}
+      {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/livekit-server/templates/service.yaml
+++ b/livekit-server/templates/service.yaml
@@ -4,13 +4,15 @@ metadata:
   name: {{ include "livekit-server.fullname" . }}
   labels:
     {{- include "livekit-server.labels" . | nindent 4 }}
-  {{- if eq .Values.loadBalancer.type "aws" }}
   annotations:
+  {{- if eq .Values.loadBalancer.type "aws" }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
-  {{- else if or (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") }}
-  annotations:
+  {{- else if or (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") (eq .Values.loadBalancer.type "gke-vpc-native") }}
     cloud.google.com/backend-config: '{"ports": {"{{ .Values.loadBalancer.servicePort }}":"{{ include "livekit-server.fullname" . }}"}}'
+  {{- end }}
+  {{- if eq .Values.loadBalancer.type "gke-vpc-native" }}
+    cloud.google.com/neg: '{"ingress": true}'
   {{- end }}
 spec:
   {{- if or (eq .Values.loadBalancer.type "alb") (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") (eq .Values.loadBalancer.type "do") }}

--- a/server-sample.yaml
+++ b/server-sample.yaml
@@ -49,7 +49,7 @@ livekit:
     serviceType: "LoadBalancer"
 
 loadBalancer:
-  # valid values: disable, alb, aws, gke, gke-managed-cert, do
+  # valid values: disable, alb, aws, gke, gke-managed-cert, gke-native-vpc, do
   # on AWS, we recommend using alb load balancer, which supports TLS termination
   # * in order to use alb, aws-ingress-controller must be installed
   #   https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html


### PR DESCRIPTION
We would like to deploy LiveKit into a [VPC-native GKE cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#overview).
To accomodate this we had to make to following changes:
* Introduce a new LB type `gke-native-vpc`
* Add the annotation `[cloud.google.com/neg](http://cloud.google.com/neg): '{"ingress": true}'` to the service
* Change the service from `type: NodePort` to `ClusterIp`