### PR TITLE
Fix indentation in ingress.yaml

### DIFF
--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -55,21 +55,21 @@ spec:
   {{- end }}
   {{- end }}
 {{- if ne .Values.loadBalancer.type "gke-vpc-native" }}
-  {{- with .Values.loadBalancer }}
-    {{- if .tls }}
-    tls:
-      {{- range .tls }}
-      {{- if .hosts }}
-      - hosts:
-          {{- range .hosts }}
-          - {{ . | quote }}
-          {{- end }}
-        {{- if .secretName }}
-        secretName: {{ .secretName | quote }}
+{{- with .Values.loadBalancer }}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    {{- if .hosts }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
         {{- end }}
-      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName | quote }}
       {{- end }}
     {{- end }}
+    {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The v1.4.2 release was not able to deploy to gke with tls option, so I fixed it.
I'm seeing it as being caused by the tls indentation being off in ingress.yaml.

Related: #66

## Logs

I checked that the dry-run of examples/server-gke.yaml passes in each version.

### v1.4.1 (passed)

<details>
<detail>

```
$ git checkout v1.4.1    
HEAD is now at 18c3e8c livekit-server 1.4.1
$ helm install --dry-run livekit ./livekit-server --values examples/server-gke.yaml
NAME: livekit
LAST DEPLOYED: Thu May 18 18:01:31 2023
NAMESPACE: default
STATUS: pending-install
REVISION: 1
HOOKS:
---
# Source: livekit-server/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "livekit-livekit-server-test-connection"
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['livekit-livekit-server:80']
  restartPolicy: Never
MANIFEST:
---
# Source: livekit-server/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: livekit-livekit-server
data:
  config.yaml: |
    keys:
      <key>: <secret>
    log_level: info
    port: 7880
    redis:
      address: <redis-address>:6379
    rtc:
      port_range_end: 60000
      port_range_start: 50000
      tcp_port: 7881
      use_external_ip: true
    turn:
      domain: <turn-address>
      enabled: true
      loadBalancerAnnotations: {}
      secretName: <turn-tls-secret>
      tls_port: 3478
---
# Source: livekit-server/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cloud.google.com/backend-config: '{"ports": {"80":"livekit-livekit-server"}}'
spec:
  type: NodePort
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
---
# Source: livekit-server/templates/turnloadbalancer.yaml
apiVersion: v1
kind: Service
metadata:
  name: 'livekit-livekit-server-turn'
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: LoadBalancer 
  ports:
    - port: 443
      targetPort: 3478
      protocol: TCP
  selector:
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
---
# Source: livekit-server/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: livekit-server
      app.kubernetes.io/instance: livekit
  template:
    metadata:
      annotations:
        linkerd.io/inject: disabled
        sidecar.istio.io/inject: "false"
        checksum/config: 9ebf0f90e361309e3feb835a35f36d4ec16c141b581054b55bfc9e5ec848b7c2
      labels:
        app.kubernetes.io/name: livekit-server
        app.kubernetes.io/instance: livekit
    spec:
      serviceAccountName: default
      securityContext:
        {}
      dnsPolicy: ClusterFirstWithHostNet
      hostNetwork: true
      terminationGracePeriodSeconds: 18000
      containers:
        - name: livekit-server
          securityContext:
            {}
          image: "livekit/livekit-server:v1.4.1"
          imagePullPolicy: IfNotPresent
          args: ["--disable-strict-config"]
          env:
            - name: LIVEKIT_CONFIG
              valueFrom:
                configMapKeyRef:
                  name: livekit-livekit-server
                  key: config.yaml
            - name: LIVEKIT_TURN_CERT
              value: /etc/lkcert/tls.crt
            - name: LIVEKIT_TURN_KEY
              value: /etc/lkcert/tls.key
          ports:
            - name: http
              containerPort: 7880
              protocol: TCP
            - name: rtc-tcp
              containerPort: 7881
              hostPort: 7881
              protocol: TCP
            - name: turn-tls
              containerPort: 3478
              hostPort: 3478
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /
              port: http
          readinessProbe:
            httpGet:
              path: /
              port: http
          resources:
            limits:
              cpu: 7500m
              memory: 2048Mi
            requests:
              cpu: 7000m
              memory: 1024Mi
          volumeMounts:
            - name: lkturncert
              mountPath: /etc/lkcert
              readOnly: true
      volumes:
        - name: lkturncert
          secret:
            secretName: <turn-tls-secret>
---
# Source: livekit-server/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: livekit-livekit-server
  minReplicas: 1
  maxReplicas: 5
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 60
---
# Source: livekit-server/templates/ingress.yaml
kind: Ingress
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.1
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
  # custom annotations
  # AWS ALB
  # GKE with managed certs
  # DO with cert manager
apiVersion: networking.k8s.io/v1
spec:
  rules:
  # In order to work with cert manager on DO, we cannot set us as a default backend
  - host: "<server-address>"
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: livekit-livekit-server
            port:
              number: 80
  tls:
    - hosts:
        - "<server-address>"
      secretName: "<server-tls-secret>"
---
# Source: livekit-server/templates/backendconfig.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: livekit-livekit-server
spec:
  # 10h timeout for websocket
  timeoutSec: 36000
  connectionDraining:
    drainingTimeoutSec: 60

NOTES:
-------------------------------------------------------------------------------

LiveKit v1.4.1 has been deployed!

Please ensure that the following ports on the nodes are open on your firewall.
* WebRTC UDP 50000 - 60000
* WebRTC TCP 7881
* TURN/TLS 3478

Primary load balancer has been set up for the primary API endpoint. The
following hosts should now be pointed at the load balancer.
  - <server-address>

To determine the load balancer address, run:
  $ kubectl get --namespace default ingress livekit-livekit-server

TURN/TLS has been deployed behind a load balancer, to determine its address, run:
  $ kubectl get --namespace default service livekit-livekit-server-turn
You may now map the TURN/TLS domain <turn-address> to this address

-------------------------------------------------------------------------------
$ 
```

</detail>
</details>


### v1.4.2 (failed)

<details>
<detail>

```
$ git checkout v1.4.2
Previous HEAD position was 18c3e8c livekit-server 1.4.1
HEAD is now at 3bb4250 server 1.4.2
$ helm install --dry-run livekit ./livekit-server --values examples/server-gke.yaml
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Ingress.spec.rules[0]): unknown field "tls" in io.k8s.api.networking.v1.IngressRule
$
```

</detail>
</details>

### This PR (passed)

<details>
<detail>

```
$ git checkout fix-ingress-indent 
Previous HEAD position was 3bb4250 server 1.4.2
Switched to branch 'fix-ingress-indent'
$ helm install --dry-run livekit ./livekit-server --values examples/server-gke.yaml
NAME: livekit
LAST DEPLOYED: Thu May 18 18:06:11 2023
NAMESPACE: default
STATUS: pending-install
REVISION: 1
HOOKS:
---
# Source: livekit-server/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "livekit-livekit-server-test-connection"
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['livekit-livekit-server:80']
  restartPolicy: Never
MANIFEST:
---
# Source: livekit-server/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: livekit-livekit-server
data:
  config.yaml: |
    keys:
      <key>: <secret>
    log_level: info
    port: 7880
    redis:
      address: <redis-address>:6379
    rtc:
      port_range_end: 60000
      port_range_start: 50000
      tcp_port: 7881
      use_external_ip: true
    turn:
      domain: <turn-address>
      enabled: true
      loadBalancerAnnotations: {}
      secretName: <turn-tls-secret>
      tls_port: 3478
---
# Source: livekit-server/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cloud.google.com/backend-config: '{"ports": {"80":"livekit-livekit-server"}}'
spec:
  type: NodePort
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
---
# Source: livekit-server/templates/turnloadbalancer.yaml
apiVersion: v1
kind: Service
metadata:
  name: 'livekit-livekit-server-turn'
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
spec:
  type: LoadBalancer 
  ports:
    - port: 443
      targetPort: 3478
      protocol: TCP
  selector:
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
---
# Source: livekit-server/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: livekit-server
      app.kubernetes.io/instance: livekit
  template:
    metadata:
      annotations:
        linkerd.io/inject: disabled
        sidecar.istio.io/inject: "false"
        checksum/config: 9ebf0f90e361309e3feb835a35f36d4ec16c141b581054b55bfc9e5ec848b7c2
      labels:
        app.kubernetes.io/name: livekit-server
        app.kubernetes.io/instance: livekit
    spec:
      serviceAccountName: default
      securityContext:
        {}
      dnsPolicy: ClusterFirstWithHostNet
      hostNetwork: true
      terminationGracePeriodSeconds: 18000
      containers:
        - name: livekit-server
          securityContext:
            {}
          image: "livekit/livekit-server:v1.4.2"
          imagePullPolicy: IfNotPresent
          args: ["--disable-strict-config"]
          env:
            - name: LIVEKIT_CONFIG
              valueFrom:
                configMapKeyRef:
                  name: livekit-livekit-server
                  key: config.yaml
            - name: LIVEKIT_TURN_CERT
              value: /etc/lkcert/tls.crt
            - name: LIVEKIT_TURN_KEY
              value: /etc/lkcert/tls.key
          ports:
            - name: http
              containerPort: 7880
              protocol: TCP
            - name: rtc-tcp
              containerPort: 7881
              hostPort: 7881
              protocol: TCP
            - name: turn-tls
              containerPort: 3478
              hostPort: 3478
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /
              port: http
          readinessProbe:
            httpGet:
              path: /
              port: http
          resources:
            limits:
              cpu: 7500m
              memory: 2048Mi
            requests:
              cpu: 7000m
              memory: 1024Mi
          volumeMounts:
            - name: lkturncert
              mountPath: /etc/lkcert
              readOnly: true
      volumes:
        - name: lkturncert
          secret:
            secretName: <turn-tls-secret>
---
# Source: livekit-server/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: livekit-livekit-server
  minReplicas: 1
  maxReplicas: 5
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 60
---
# Source: livekit-server/templates/ingress.yaml
kind: Ingress
metadata:
  name: livekit-livekit-server
  labels:
    helm.sh/chart: livekit-server-1.4.2
    app.kubernetes.io/name: livekit-server
    app.kubernetes.io/instance: livekit
    app.kubernetes.io/version: "v1.4.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
  # custom annotations
  # AWS ALB
  # GKE with managed certs
  # DO with cert manager
apiVersion: networking.k8s.io/v1
spec:
  rules:
  # In order to work with cert manager on DO, we cannot set us as a default backend
  - host: "<server-address>"
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: livekit-livekit-server
            port:
              number: 80
  tls:
    - hosts:
        - "<server-address>"
      secretName: "<server-tls-secret>"
---
# Source: livekit-server/templates/backendconfig.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: livekit-livekit-server
spec:
  # 10h timeout for websocket
  timeoutSec: 36000
  connectionDraining:
    drainingTimeoutSec: 60

NOTES:
-------------------------------------------------------------------------------

LiveKit v1.4.2 has been deployed!

Please ensure that the following ports on the nodes are open on your firewall.
* WebRTC UDP 50000 - 60000
* WebRTC TCP 7881
* TURN/TLS 3478

Primary load balancer has been set up for the primary API endpoint. The
following hosts should now be pointed at the load balancer.
  - <server-address>

To determine the load balancer address, run:
  $ kubectl get --namespace default ingress livekit-livekit-server

TURN/TLS has been deployed behind a load balancer, to determine its address, run:
  $ kubectl get --namespace default service livekit-livekit-server-turn
You may now map the TURN/TLS domain <turn-address> to this address

-------------------------------------------------------------------------------
$ 
```

</detail>
</details>