### PR TITLE
allow custom spec on backendconfig for gcp

### DIFF
--- a/livekit-server/templates/backendconfig.yaml
+++ b/livekit-server/templates/backendconfig.yaml
@@ -4,8 +4,5 @@ kind: BackendConfig
 metadata:
   name: {{ include "livekit-server.fullname" . }}
 spec:
-  # 10h timeout for websocket
-  timeoutSec: 36000
-  connectionDraining:
-    drainingTimeoutSec: 60
+  {{ .Values.gcp.backendConfig | toPrettyJson }}
 {{ end }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -128,3 +128,11 @@ affinity: {}
 deploymentStrategy: {}
 
 deploymentAnnotations: {}
+
+# Specifies configuration gke backendconfig
+gcp: 
+  backendConfig: 
+    # 10h timeout for websocket
+    timeoutSec: 36000
+    connectionDraining:
+      drainingTimeoutSec: 60


### PR DESCRIPTION
We would like to deploy LiveKit with security policy (Cloud Armor WAF) on backendconfig  