### PR TITLE
Add value option to choose DaemonSet instead of Deployment

### DIFF
--- a/livekit-server/templates/deployment-daemonset.yaml
+++ b/livekit-server/templates/deployment-daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.deploymentType }}
 metadata:
   name: {{ include "livekit-server.fullname" . }}
   labels:
@@ -9,13 +9,13 @@ metadata:
     {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (eq .Values.deploymentType "Deployment") }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "livekit-server.selectorLabels" . | nindent 6 }}
-  {{- if .Values.deploymentStrategy }}
+  {{- if and (.Values.deploymentStrategy) (eq .Values.deploymentType "Deployment") }}
   strategy:
     {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   {{- end }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+# deploymentType can be one of "Deployment", "DaemonSet"
+deploymentType: Deployment
+
 image:
   repository: livekit/livekit-server
   pullPolicy: IfNotPresent


### PR DESCRIPTION
For example, we have a case where we add dedicated Kubernetes Worker nodes exclusively to run Livekit pods (as you know, Livekit can require a lot of CPU and network resources). In that case, we simply add specific Node Labels to those nodes, and then we can deploy this chart using `deploymentType: DaemonSet` and applicable `nodeSelector` values to deploy Livekit automatically for each new Kubernetes node with those labels.