### PR TITLE
Add value to control whether TURN loadbalancer needs to be created

### DIFF
--- a/livekit-server/templates/turnloadbalancer.yaml
+++ b/livekit-server/templates/turnloadbalancer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port }}
+{{- if and (and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port) .Values.turnLoadbalancer.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }} 
+  type: {{ default "LoadBalancer" .Values.livekit.turn.serviceType }}
   ports:
     - port: 443
       targetPort: {{ .Values.livekit.turn.tls_port }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -68,6 +68,9 @@ loadBalancer:
   servicePort: 80
   annotations: {}
 
+turnLoadbalancer:
+  enable: true
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
For example, in our case we configured the TURN loadbalancer separately, i.e. via a Traefik `IngressRoute` object.