### PR TITLE
Make Ingress optional and ingressClass configurable

### DIFF
--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.loadBalancer.type "disable") (ne .Values.loadBalancer.type "gclb") -}}
+{{- if and (ne .Values.loadBalancer.type "disable") (ne .Values.loadBalancer.type "gclb") (eq .Values.ingress.enable true) -}}
 {{- $fullName := include "livekit-server.fullname" . -}}
 {{- $svcPort := .Values.loadBalancer.servicePort -}}
 kind: Ingress
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
   # AWS ALB
   {{- if eq .Values.loadBalancer.type "alb" }}
-    kubernetes.io/ingress.class: alb
+    kubernetes.io/ingress.class: {{ default "alb" .Values.ingress.ingressClass }}
     alb.ingress.kubernetes.io/scheme: internet-facing
     {{- if .Values.loadBalancer.tls }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
@@ -23,7 +23,7 @@ metadata:
   {{- if eq .Values.loadBalancer.type "gke-managed-cert" }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.loadBalancer.staticIpName }}
     networking.gke.io/managed-certificates: {{ or .Values.loadBalancer.certificateName "managed-cert" }}
-    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.class: {{ default "gce" .Values.ingress.ingressClass }}
   {{- end }}
   # DO with cert manager
   {{- if eq .Values.loadBalancer.type "do" }}
@@ -36,7 +36,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 spec:
   {{- if eq .Values.loadBalancer.type "do" }}
-  ingressClassName: nginx
+  ingressClassName: {{ default "nginx" .Values.ingress.ingressClass }}
   {{- end }}
   rules:
   # In order to work with cert manager on DO, we cannot set us as a default backend

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -63,6 +63,11 @@ storeKeysInSecret:
 nameOverride: ""
 fullnameOverride: ""
 
+ingress:
+  enable: true
+  # Uncomment to override ingressClass from the default
+  # ingressClass: traefik
+
 loadBalancer:
   type: disable
   servicePort: 80


### PR DESCRIPTION
A bigger rework of the chart comes to my mind but this suffices for my usecase.
Should be compatible with whatever 


Commenting on related things, fully decoupling the helmchart from gke/aws/do would be optimal, as there's really nothing that actually ties LiveKit to them. Ingress should also be decoupled from the load balancing, as TLS-terminating LBs can avoid the need for one if the user configured them.

Bringing up the chart to ie. Bitnami standard to allow fully changing every parameter would be a lot of work but ultimately desirable. I totally understand this may be out of scope for the chart and "users bring their your own yaml" may be preferred. 

