### PR TITLE
feat: allow to configure livekit Deployment as StatefulSet

### DIFF
--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ default "Deployment" .Values.deploymentType }}
 metadata:
   name: {{ include "livekit-server.fullname" . }}
   labels:

--- a/livekit-server/templates/hpa.yaml
+++ b/livekit-server/templates/hpa.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ default "Deployment" .Values.deploymentType }}
     name: {{ include "livekit-server.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -130,6 +130,9 @@ affinity: {}
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#deploymentstrategy-v1-apps
 deploymentStrategy: {}
 
+# can be set to StatefulSet to get predictive (down)scaling behavior
+deploymentType: Deployment
+
 deploymentAnnotations: {}
 
 # Specifies configuration gke backendconfig


### PR DESCRIPTION
This change allows Livekit to be deployed as a StatefulSet instead of a Deployment.

## Motivation

Our main setup are 3 nodes on a fixed pool. For scaling we use a different, dynamic pool and when scaling down, we of course want pods from the dynamic pool to be selected for killing. Otherwise, when scaling down the pool we will have to move a pod again. Apparently Kubernetes doesn't expose many options to select pods for scaling down, so we came up with this approach.

For a StatefulSet with scale `N`, Kubernetes guarantees to kill pod `N-1` when scaling down. As our base nodes will always have indices 0-2, this approach will guarantee killing a pod on the dynamic pool

## TBD

The current change lets the user define the deployment `kind` as a raw field, where really only two values are supported. One other way I can think of would be a boolean `deployAsStatefulSet` variable that then selects the proper value in the templates.