### PR TITLE
make the servicePort optional for lk-ingress load balancer

### DIFF
--- a/ingress/templates/service.yaml
+++ b/ingress/templates/service.yaml
@@ -6,9 +6,11 @@ metadata:
 spec:
   type: {{ default "LoadBalancer" .Values.ingress.serviceType }}
   ports:
+    {{- if .Values.loadBalancer.servicePort }}
     - port: {{ .Values.loadBalancer.servicePort }}
       protocol: TCP
       name: ws
+    {{- end }}
     - port: {{ .Values.ingress.rtmp_port }}
       protocol: TCP
       name: rtmp


### PR DESCRIPTION
This PR makes the servicePort an optional value for the load balancer on liveit-ingress. It maps to the internal health port which isn't necessary for external access.