### PR TITLE
fix: add labels on servicemonitor

### DIFF
--- a/livekit-server/templates/servicemonitor.yaml
+++ b/livekit-server/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "livekit-server.serviceMonitorName" . }}
   labels:
     {{- include "livekit-server.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -143,6 +143,8 @@ gcp:
 serviceMonitor:
   # Specifies whether a service monitor should be created
   create: false
+  # Labels to add to the service monitor
+  labels: {}
   # Annotations to add to the service monitor
   annotations: {}
   # The name of the service monitor to use.


### PR DESCRIPTION
fix:
- #97 

duplicate to:
- #106 

The use case is that a standard deployment of the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) expects labels on the pod monitor and cannot find the monitor otherwise.