### PR TITLE
docs: add some comment for value podHostNetwork

### DIFF
--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -104,6 +104,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# By default, the `hostNetwork: true` is used for the pods. This means that the pods
+# receive the IP address of the node and not a private one from kubernetes.
+# There may be constellations in which this must be disabled. But it is not recommended.
+# Be careful as this leads to single port UDP usage and can lead to performance losses.
 podHostNetwork: true
 
 podAnnotations:


### PR DESCRIPTION
Follow up to:
- https://github.com/livekit/livekit-helm/pull/53#issuecomment-1425395030

Add only some docs.

I needed one because to find or perceive the schlater. But it solves my problem.

My use case: I am use `serviceType: “LoadBalancer”` for the turn server. However, the external loadbalancer cannot direct route traffic to the nodeport ip address, but only to the internal ip address. I also use the TURN only with TCP and not UDP