### PR TITLE
feat: allow to set custom ENV

### DIFF
--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
             - name: LIVEKIT_TURN_KEY
               value: /etc/lkcert/tls.key
             {{- end }}
+            {{- with .Values.extraEnvVars }}
+              {{ toYaml . | indent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.livekit.port }}

--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               value: /etc/lkcert/tls.key
             {{- end }}
             {{- with .Values.extraEnvVars }}
-              {{ toYaml . | indent 12 }}
+              {{- toYaml . | indent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -84,6 +84,17 @@ nodeSelector:
   {}
   # node.kubernetes.io/instance-type: c5.2xlarge
 
+# Additional environment variables to set
+# Ref: https://github.com/livekit/livekit/blob/master/cmd/server/main.go
+extraEnvVars: []
+  # - name: CUSTOM_VAR
+  #   value: "custom-value"
+  # - name: REDIS_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: secret-key
+
 resources:
   {}
   # Due to port restrictions, you can run only one instance of LiveKit per physical


### PR DESCRIPTION
This PR allows you to set your own environment variables.

This makes it possible, for example, to overwrite the host IP or the Redis password from secrets.

This is a generic approach so that switches do not have to be provided for all possibilities.

Related:
- #111

List of variables: https://github.com/livekit/livekit/blob/master/cmd/server/main.go