### PR TITLE
feat: add native Azure support and configurable ingress for livekit-server chart

### DIFF
--- a/livekit-server/templates/ingress.yaml
+++ b/livekit-server/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.loadBalancer.type "disable") (ne .Values.loadBalancer.type "gclb") -}}
+{{- if and .Values.loadBalancer.ingress.enabled (ne .Values.loadBalancer.type "disable") (ne .Values.loadBalancer.type "gclb") (ne .Values.loadBalancer.type "azure") -}}
 {{- $fullName := include "livekit-server.fullname" . -}}
 {{- $svcPort := .Values.loadBalancer.servicePort -}}
 kind: Ingress

--- a/livekit-server/templates/service.yaml
+++ b/livekit-server/templates/service.yaml
@@ -40,6 +40,16 @@ spec:
       protocol: UDP
       targetPort: rtc-udp
     {{- end }}
+    {{- if or (eq .Values.loadBalancer.type "azure") }}
+    - name: turn-udp
+      port: {{ .Values.livekit.turn.udp_port | default 3478 }}
+      protocol: UDP
+      targetPort: turn-udp
+    - name: turn-tcp
+      port: {{ .Values.livekit.turn.tcp_port | default 3478 }}
+      protocol: TCP
+      targetPort: turn-tcp
+    {{- end }}
     {{- if .Values.livekit.prometheus_port }}
     - port: {{ .Values.livekit.prometheus_port }}
       targetPort: metrics

--- a/livekit-server/templates/service.yaml
+++ b/livekit-server/templates/service.yaml
@@ -18,9 +18,9 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
   {{- end }}
 spec:
-  {{- if or (eq .Values.loadBalancer.type "alb") (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") (eq .Values.loadBalancer.type "do") (eq .Values.loadBalancer.type "gclb")}}
+  {{- if or (eq .Values.loadBalancer.type "alb") (eq .Values.loadBalancer.type "gke") (eq .Values.loadBalancer.type "gke-managed-cert") (eq .Values.loadBalancer.type "do") (eq .Values.loadBalancer.type "gclb") }}
   type: NodePort
-  {{- else if eq .Values.loadBalancer.type "aws" }}
+  {{- else if or (eq .Values.loadBalancer.type "aws") (eq .Values.loadBalancer.type "azure") }}
   type: LoadBalancer
   {{- end }}
   ports:
@@ -28,13 +28,13 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if and (or (eq .Values.loadBalancer.type "disable") (eq .Values.loadBalancer.type "gclb")) .Values.livekit.rtc.tcp_port }}
+    {{- if and (or (eq .Values.loadBalancer.type "disable") (eq .Values.loadBalancer.type "gclb") (eq .Values.loadBalancer.type "azure")) .Values.livekit.rtc.tcp_port }}
     - name: rtc-tcp
       port: {{ .Values.livekit.rtc.tcp_port }}
       protocol: TCP
       targetPort: rtc-tcp
     {{- end }}
-    {{- if and (or (eq .Values.loadBalancer.type "disable") (eq .Values.loadBalancer.type "gclb")) .Values.livekit.rtc.udp_port }}
+    {{- if and (or (eq .Values.loadBalancer.type "disable") (eq .Values.loadBalancer.type "gclb") (eq .Values.loadBalancer.type "azure")) .Values.livekit.rtc.udp_port }}
     - name: rtc-udp
       port: {{ .Values.livekit.rtc.udp_port }}
       protocol: UDP

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -68,6 +68,8 @@ loadBalancer:
   type: disable
   servicePort: 80
   annotations: {}
+  # ingress.enabled controls the automatic generation of an Ingress resource.
+  # Set to false when using a dedicated LoadBalancer for media/RTC and a manual Ingress for Signal (Best Practice).
   ingress:
     enabled: true
 

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -64,9 +64,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 loadBalancer:
+  # type can be: disable, aws, alb, gke, gke-managed-cert, gke-vpc-native, do, gclb, azure
   type: disable
   servicePort: 80
   annotations: {}
+  ingress:
+    enabled: true
 
 turnLoadbalancer:
   enable: true


### PR DESCRIPTION
# Add Native Azure LoadBalancer Support for LiveKit Server

### Problem Statement
On **Azure AKS**, using `HostNetwork` or `ClusterIP` for LiveKit often leads to WebRTC connection failures due to Azure's strict Outbound NAT restrictions. Standard Ingress Controllers (like Nginx) also face challenges routing high-volume UDP traffic in a way that remains compatible with LiveKit's ICE candidate discovery.

### Proposed Changes
This PR introduces a new `loadBalancer.type: azure` to the `livekit-server` Helm chart, making it "Azure Native."

**Key Enhancements:**
1.  **Native Azure LoadBalancer**: Setting `loadBalancer.type: azure` automatically configures a Service of type `LoadBalancer` and correctly exposes the necessary multiplexed ports (`rtc-tcp`, `rtc-udp`, and `turn-udp/tcp`).
2.  **Decoupled Ingress Toggle**: Introduced `loadBalancer.ingress.enabled` (default: `true`). This allow users to disable the chart-generated Ingress while still using a LoadBalancer for Media traffic. This is a **Best Practice** for Azure, where SSL is often handled by a manual/separate Ingress while Media goes through a dedicated LB IP.
3.  **TURN Port Exposure**: Automatically exposes port `3478` (UDP/TCP) when the Azure LoadBalancer is active to ensure reliable fallback connectivity.

### Why this is needed
Azure's LoadBalancer doesn't support massive UDP port ranges easily. By providing a native type that focuses on multiplexed ports and allowing users to decouple Ingress from the Service, we enable a stable, production-ready LiveKit deployment on Azure with minimal manual overrides.

## Design Decisions & Best Practices
1. **Hybrid Networking Model**: In high-scale WebRTC deployments (like on Azure AKS), it is a **Best Practice** to decouple the Signal traffic (WSS/443) from the Media traffic (UDP).
   - **Signal**: Handled by the existing cluster Ingress Controller (Nginx/Traefik) for easy SSL termination and standard HTTP features.
   - **Media**: Handled by a dedicated, high-performance LoadBalancer IP to bypass Azure's Outbound NAT limitations without overwhelming the Ingress Controller with raw UDP traffic.
2. **"Freedom of Choice" (Flexibility)**: By introducing the `loadBalancer.ingress.enabled` toggle, this chart remains beginner-friendly (default: `true`) while empowering enterprise users to disable the automatic Ingress and use their own manual/centralized Ingress setup.


### How to Test:

1.  **Validate Helm Template Output**:
    Run `helm template . -f values.yaml` and verify:
    -   The `Service` should have `type: LoadBalancer`.
    -   Ports `7881` (RTC TCP) and `3478` (TURN UDP/TCP) should be present in the Service spec.
    -   No `Ingress` resource should be generated if `loadBalancer.ingress.enabled` is set to `false`.

2.  **Verify on Azure AKS**:
    Deploy the chart to an Azure cluster with the following values:
    ```yaml
    loadBalancer:
      type: azure
      ingress:
        enabled: false
    livekit:
      rtc:
        use_external_ip: false
        node_ip: <EXTERNAL_IP_OF_LOADBALANCER>
    ```
    - Verify that a dedicated LoadBalancer is created by Azure with a Public IP.

3.  **End-to-End Connectivity**:
    Run the [LiveKit Connection Test](https://livekit.com/webrtc/connection-test) using the server's domain (via a manual Ingress) and verify that:
    -   The Signal connection (WSS) is established.
    -   Audio/Video packets are successfully published and received.
    -   ICE candidates point to the dedicated LoadBalancer IP.
