### PR TITLE
Add customizable environment and volume options

### DIFF
--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -60,6 +60,13 @@ spec:
             - name: LIVEKIT_TURN_KEY
               value: /etc/lkcert/tls.key
             {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.livekit.port }}

--- a/livekit-server/templates/deployment.yaml
+++ b/livekit-server/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.storeKeysInSecret.enabled (and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls)) }}
+          {{- if or .Values.storeKeysInSecret.enabled (and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls)) .Values.extraVolumeMounts }}
           volumeMounts:
           {{- if .Values.storeKeysInSecret.enabled }}
             - name: keys-volume
@@ -125,8 +125,11 @@ spec:
               mountPath: /etc/lkcert
               readOnly: true
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or .Values.storeKeysInSecret.enabled (and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls)) }}
+          {{- end }}
+      {{- if or .Values.storeKeysInSecret.enabled (and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls)) .Values.extraVolumes }}
       volumes:
         {{- if .Values.storeKeysInSecret.enabled }}
         - name: keys-volume
@@ -138,6 +141,9 @@ spec:
         - name: lkturncert
           secret:
             secretName: {{ required "tls secret required if turn enabled" .Values.livekit.turn.secretName }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -26,6 +26,22 @@ extraEnvFrom: []
 # - secretRef:
 #     name: livecircle-external-env-secrets
 
+# Extra volumes to attach to the pod. Useful for mounting CA certificate
+# bundles, additional config files, etc.
+extraVolumes: []
+# - name: redis-ca
+#   secret:
+#     secretName: my-secret
+#     items:
+#       - key: REDIS_CA_CERT
+#         path: ca.crt
+
+# Extra volumeMounts for the livekit-server container. Pair with extraVolumes.
+extraVolumeMounts: []
+# - name: redis-ca
+#   mountPath: /etc/redis-ca
+#   readOnly: true
+
 terminationGracePeriodSeconds: 18000
 
 # configuration for livekit

--- a/livekit-server/values.yaml
+++ b/livekit-server/values.yaml
@@ -10,6 +10,22 @@ image:
 
 imagePullSecrets: []
 
+# Extra environment variables for the livekit-server container.
+# Use this to inject secrets via valueFrom.secretKeyRef without baking
+# them into the plaintext ConfigMap. LiveKit substitutes ${VAR} in its
+# YAML config at startup, so you can reference these from livekit.* below.
+extraEnv: []
+# - name: REDIS_PASSWORD
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-redis-secret
+#       key: password
+
+# Extra envFrom sources (e.g. envFrom an existing Secret in bulk).
+extraEnvFrom: []
+# - secretRef:
+#     name: livecircle-external-env-secrets
+
 terminationGracePeriodSeconds: 18000
 
 # configuration for livekit


### PR DESCRIPTION
1. Make it possible to populate secrets (such as redis password) from k8s secrets (fits nicely with terraform + [external secrets operator](https://external-secrets.io/latest/provider/google-secrets-manager/))
2. Make it possible to mount the Google Memstore (Redis) CA into the container (Google Memstore Redis is per instance, so every Redis you have you have a different CA cert you need to use, lame but that's how Google has implemented it.
Hope this is of use to y'all 

TLDR;

Enhance LiveKit Helm chart with `extraEnv`, `extraEnvFrom`, `extraVolumes`, and `extraVolumeMounts` to allow flexible configuration and secure secret injection. This provides advanced customization capabilities for the LiveKit server deployment.

### Review Focus
Verify the templating logic for `extraEnv`, `extraEnvFrom`, `extraVolumes`, and `extraVolumeMounts` correctly integrates into the deployment manifest.

### How to Test
Deploy the chart with custom values for `extraEnv`, `extraEnvFrom`, `extraVolumes`, and `extraVolumeMounts`, then inspect the resulting Kubernetes deployment for correct application.